### PR TITLE
chore: revert version and remove deprecated keyword from package.json

### DIFF
--- a/packages/tusk/package.json
+++ b/packages/tusk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tusk",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "description": "Tusk lets you carve into JavaScript, TypeScript, and beyond with raw power.",
   "main": "build/index.js",
   "type": "module",
@@ -11,7 +11,6 @@
     "test": "poku --sequential"
   },
   "keywords": [
-    "deprecated",
     "tusk",
     "patch",
     "monkey-patch",


### PR DESCRIPTION
Fixes a wrong version that was previously committed and removes a deprecated keyword that no longer has any effect.